### PR TITLE
Enable to use string in :access-control-request-headers

### DIFF
--- a/src/ring/middleware/cors.clj
+++ b/src/ring/middleware/cors.clj
@@ -13,14 +13,20 @@
   [request]
   (= (request :request-method) :options))
 
+(defn lower-case-set
+  "Converts strings in a sequence to lower-case, and put them into a set"
+  [s]
+  (->> s
+      (map str/trim)
+      (map str/lower-case)
+      (set)))
+
 (defn parse-headers
   "Transforms a comma-separated string to a set"
   [s]
   (->> (str/split (str s) #",")
        (remove str/blank?)
-       (map str/trim)
-       (map str/lower-case)
-       (set)))
+       (lower-case-set)))
 
 (defn allow-preflight-headers?
   "Returns true if the request is a preflight request and all the headers that
@@ -30,7 +36,7 @@
     true
     (set/subset?
      (parse-headers (get-header request "access-control-request-headers"))
-     (set (map name allowed-headers)))))
+     (lower-case-set (map name allowed-headers)))))
 
 (defn allow-method?
   "In the case of regular requests it checks if the request-method is allowed.

--- a/test/ring/middleware/cors_test.clj
+++ b/test/ring/middleware/cors_test.clj
@@ -173,3 +173,17 @@
     "Accept" #{"accept"}
     "Accept, Content-Type" #{"accept" "content-type"}
     " Accept ,  Content-Type " #{"accept" "content-type"}))
+
+(deftest test-preflight-headers?
+  (testing "Acceptable allowed-headers"
+    (let [headers {"Access-Control-Allow-Headers" "Accept, Content-Type"}
+          request {:request-method :get
+                   :uri "/"
+                   :headers headers}]
+      (are [allowed-headers]
+          (is (true? (allow-preflight-headers? request allowed-headers)))
+        [:accept :content-type]
+        [:Accept :Content-Type]
+        ["accept" "content-type"]
+        ["Accept" "Content-Type"]
+        ["  cOntenT-typE " " acCePt"]))))


### PR DESCRIPTION
Hi @r0man , thanks for your great work.

The other day I was stuck for hours with following code.

```
(wrap-cors handler
           ...
             :access-control-allow-headers ["Accept" "Content-Type"])
```

I looked over ```cors.clj```, and figured out I should have had

```
             :access-control-allow-headers [:accept :content-type])
```

Then let me suggest allowing users to use string in :access-control-allow-headers.
I believe it'd be helpful for coming users.

Thank you for your work and time.