### PR TITLE
Allow passing a var to `:access-control-allow-origin`

### DIFF
--- a/src/ring/middleware/cors.cljc
+++ b/src/ring/middleware/cors.cljc
@@ -82,13 +82,13 @@
         allowed-headers (:access-control-allow-headers access-control)
         allowed-methods (:access-control-allow-methods access-control)]
     (if (and origin
-             (if (fn? allowed-origins)
-               true
-               (seq allowed-origins))
+             (if (sequential? allowed-origins)
+               (seq allowed-origins)
+               true)
              (seq allowed-methods)
-             (if (fn? allowed-origins)
-               (allowed-origins request)
-               (some #(re-matches % origin) allowed-origins))
+             (if (sequential? allowed-origins)
+               (some #(re-matches % origin) allowed-origins)
+               (allowed-origins request))
              ;;...or else it's a predefined collection,
              ;;do a normal existence check.
              (if (preflight? request)
@@ -160,7 +160,7 @@
       (update-in [:access-control-allow-methods] set)
       (update-in [:access-control-allow-headers] #(if (coll? %) (set %) %))
       (update-in [:access-control-allow-origin] #(if (or (sequential? %)
-                                                         (fn? %))
+                                                         (ifn? %))
                                                    %
                                                    [%]))))
 


### PR DESCRIPTION
This allows you to pass a var as `:access-control-allow-origin`. It's nice in development because you can make changes to the function without having to restart the server.

Example:

```clojure
(defn allow-origin? [req]
  (= (:uri req) "/my-cors-path"))
  
(wrap-cors handler :access-control-allow-origin #'allow-origin?)
```